### PR TITLE
fix: zamiana martwych serwisów placeholderów obrazków

### DIFF
--- a/apps/1-app-display-single-image/index.html
+++ b/apps/1-app-display-single-image/index.html
@@ -4,6 +4,6 @@
     <script src="scripts/boot.js"></script>
 </head>
 <body style="margin: 0px;">
-<img src="http://lorempixel.com/960/540/sports/" />
+<img src="https://picsum.photos/seed/sports/960/540" />
 </body>
 </html>

--- a/apps/1-app-display-single-image/index.html
+++ b/apps/1-app-display-single-image/index.html
@@ -4,6 +4,6 @@
     <script src="scripts/boot.js"></script>
 </head>
 <body style="margin: 0px;">
-<img src="https://picsum.photos/seed/sports/960/540" />
+<img src="https://picsum.photos/seed/sports/960/540" alt="" />
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                 <code> &lt;script src="<mark class="important">scripts/boot.js</mark>"&gt;&lt;/script&gt;</code>
                 <code>&lt;/head&gt;</code>
                 <code>&lt;body style="margin: 0px;"&gt;</code>
-                <code> &lt;img src="<mark>https://picsum.photos/seed/sports/960/540</mark>" /&gt;</code>
+                <code> &lt;img src="<mark>https://picsum.photos/seed/sports/960/540</mark>" alt="" /&gt;</code>
                 <code>&lt;/body&gt;</code>
                 <code>&lt;/html&gt;</code>
             </pre>

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                 <code> &lt;script src="<mark class="important">scripts/boot.js</mark>"&gt;&lt;/script&gt;</code>
                 <code>&lt;/head&gt;</code>
                 <code>&lt;body style="margin: 0px;"&gt;</code>
-                <code> &lt;img src="<mark>http://lorempixel.com/960/540/sports/</mark>" /&gt;</code>
+                <code> &lt;img src="<mark>https://picsum.photos/seed/sports/960/540</mark>" /&gt;</code>
                 <code>&lt;/body&gt;</code>
                 <code>&lt;/html&gt;</code>
             </pre>


### PR DESCRIPTION
Serwisy via.placeholder.com, api.adorable.io, lorempixel.com, placekitten.com i unsplash.it przestały działać. Podmiana na działające odpowiedniki z zachowaniem wymiarów: via.placeholder.com → placehold.co, api.adorable.io → picsum.photos/robohash.org, lorempixel/placekitten/unsplash.it → picsum.photos.